### PR TITLE
Add SciRouter - unified API for computational drug discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,4 +379,10 @@ A meticulously curated resource list focused on computational methods for drug d
 - [QSAR4U](https://qsar4u.com/index.php) - Cheminformatics tools, QSAR modeling, CReM, and EasyDock. (Palacky University, Czechia)
 - [LBMD](https://www.chem.kuleuven.be/lbmd/index.html) - Computational strategies to understand and engineer biomolecular systems. (KU Leuven, Belgium)
 
+## API Platforms and Gateways
+
+Unified API services providing programmatic access to multiple drug discovery computational tools.
+
+- **[SciRouter](https://scirouter.ai)** - Unified API for computational drug discovery. Provides programmatic access to protein structure prediction (ESMFold), molecular docking (AutoDock Vina), binding pocket detection, ADME/Tox profiling (ADMET-AI), molecule generation (REINVENT4), synthetic accessibility scoring, target profiling (UniProt + ChEMBL + OpenTargets), protein sequence design (ProteinMPNN), antibody structure prediction (ImmuneBuilder), and CDR design (AntiFold). Includes end-to-end lab pipelines. Python SDK: `pip install scirouter`. Free tier: 500 API calls/month.
+
 ---


### PR DESCRIPTION
## SciRouter

SciRouter is a unified API gateway for computational drug discovery — providing programmatic access to GPU-accelerated open-source models without local setup.

Added as a new **API Platforms and Gateways** section at the end of the README.

**Computational drug discovery tools accessible via API:**
- Molecular docking (AutoDock Vina) — receptor PDBQT + SMILES ligands, binding poses and affinities
- ADME/Tox profiling (ADMET-AI) — drug-likeness, Lipinski, PAINS alerts, ML-based ADMET endpoints
- De novo molecule generation (REINVENT4)
- Synthetic accessibility scoring
- Target profiling (UniProt + ChEMBL + OpenTargets)
- Protein-ligand complex prediction (Chai-1)
- Binding pocket detection
- Protein structure prediction (ESMFold)
- Protein sequence design (ProteinMPNN)
- Antibody structure + CDR design (ImmuneBuilder, AntiFold)

**Access:**
- Website: https://scirouter.ai
- Python SDK: `pip install scirouter`
- Free tier: 500 credits/month, no credit card required