### PR TITLE
Add PharmaCore — local AI drug discovery on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ A meticulously curated resource list focused on computational methods for drug d
 - [ChemBERTa](https://huggingface.co/seyonec/ChemBERTa-zinc-base-v1) - Pretrained BERT-like models for molecules from SMILES.
 - [Uni-Mol](https://github.com/dptech-corp/Uni-Mol) - 3D molecular representation learning framework.
 - [Boltz-2](https://github.com/jwohlwend/boltz) - A foundation model that jointly predicts structure and binding affinity, rivaling physics-based FEP methods in accuracy.  
+- [PharmaCore](https://github.com/reacherwu/PharmaCore) - Apple Silicon-native AI drug discovery with de novo generation and drug repurposing using sparse ESM-2/ChemBERTa models (50% pruned, 97%+ quality, fully local inference).
 
 ### AutoML and Optimization
 - [Auto-sklearn](https://automl.github.io/auto-sklearn/master/) - Automated machine learning for scikit-learn.


### PR DESCRIPTION
Adding [PharmaCore](https://github.com/reacherwu/PharmaCore) to the Pretrained Models section.

PharmaCore provides sparse (50% pruned) ESM-2 and ChemBERTa models optimized for drug discovery on consumer Apple Silicon hardware. Includes de novo molecular generation and drug repurposing capabilities, all running locally without cloud dependencies.

MIT licensed.