### PR TITLE
Add CovaSyn MCP to Utility and Workflow Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ A meticulously curated resource list focused on computational methods for drug d
 - [CHEESE](https://cheese.deepmedchem.com/) - AI-driven interactive tool for analyzing chemical spaces and optimizing hit compounds.
 - [chembl_webresource_client](https://github.com/chembl/chembl_webresource_client) - Official Python client library for programmatic access to the ChEMBL database API.
 - [ChemIllusion MCP](https://chemillusion.com/mcp-server) - Model Context Protocol server providing language models with tools for generating and analyzing molecular data.
+- [CovaSyn MCP](https://www.covasyn.com) - Deterministic chemistry MCP server with 130+ tools for pharmaceutical R&D — ADMET, ICH M7 mutagenic impurity assessment, ICH Q1 stability, mass spec, NMR, formulation DoE, biologics, docking. Callable from Claude, ChatGPT, Cursor, Copilot, and any HTTP client. Audit-trail-complete, GxP-aligned, EU-hosted, free tier 100 credits/week. MIT-licensed [integration snippets](https://github.com/oliverkraft93-ops/covasyn-mcp-examples).
 - [ComProScanner](https://github.com/slimeslab/ComProScanner) - Pipeline for automated large-scale profiling and screening of chemical compounds against protein targets.
 - [NAMI](https://github.com/mqcomplab/NAMI) - Computational tool for clustering and evaluating differences across molecular datasets.
 - [Neurosnap](https://neurosnap.ai/) - Web platform providing no-code interfaces to bioinformatics and ML tools including AlphaFold.


### PR DESCRIPTION
Adds **[CovaSyn MCP](https://www.covasyn.com)** to **Utility and Workflow Tools**, right after the existing ChemIllusion MCP entry.

## What it is

A deterministic chemistry **Model Context Protocol** server providing 130+ tools across:
- Core cheminformatics, canonicalization, fingerprints, substructure search
- Chem-ADME, pKa, logP, BBB permeability
- Toxicology — ICH M7 mutagenic impurity assessment, Tox21, CYP450, structural alerts
- Mass spec — formula prediction, fragment annotation, impurity profiling
- NMR — 1D / 2D assignment, batch identification
- ICH Q1 stability — Arrhenius shelf-life estimation, photostability
- Formulation DoE — RSM optimization, crystallization, miscibility
- Biologics — antibody developability, peptide, ADC, mRNA, siRNA, oligo
- Docking — pose generation, scoring

## Why include it

- **Drug-discovery specific** — built for pharma / biotech / CDMO teams, complements existing entries (ChemIllusion MCP, Neurosnap, Datagrok, ProteinsPlus)
- **MCP-native** — works directly from Claude / ChatGPT / Cursor without custom integration code
- **Deterministic + version-pinned** — reproducible (audit-trail-complete) for regulatory work
- **Free tier** — 100 credits / week, no card
- **EU hosting** with optional self-hosted deployment
- **Benchmark** — ICLR 2026 MolecularIQ (Klambauer Lab JKU Linz): 4 frontier LLMs reach 76–92 % with CovaSyn attached vs 14–41 % baseline. Numbers + methodology + cost breakdown: [covasyn.com/en/benchmark](https://www.covasyn.com/en/benchmark)

Integration snippets (Claude Desktop, Cursor, VS Code, Python, TypeScript, curl) are MIT-licensed at [github.com/oliverkraft93-ops/covasyn-mcp-examples](https://github.com/oliverkraft93-ops/covasyn-mcp-examples).

Section choice and format follow the existing ChemIllusion MCP entry. Thanks for maintaining this list.